### PR TITLE
Add tests with Mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,5 +24,11 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/CompletionServiceImplTest.java
+++ b/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/CompletionServiceImplTest.java
@@ -1,0 +1,28 @@
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+
+import io.github.ullas.k.prabhakar.openai.OpenAIClient;
+import io.github.ullas.k.prabhakar.openai.services.impl.CompletionServiceImpl;
+import io.github.ullas.k.prabhakar.openai.vos.ChatMessage;
+import junit.framework.TestCase;
+import org.mockito.Mockito;
+
+public class CompletionServiceImplTest extends TestCase {
+    public void testCreateChatCompletion() throws Exception {
+        OpenAIClient client = Mockito.mock(OpenAIClient.class);
+        Mockito.when(client.getGson()).thenReturn(new Gson());
+        String json = "{\"choices\":[{\"message\":{\"content\":\"Hello world\"}}]}";
+        Mockito.when(client.post(Mockito.eq("/chat/completions"), Mockito.any()))
+                .thenReturn(json);
+
+        CompletionServiceImpl service = new CompletionServiceImpl(client);
+        List<ChatMessage> messages = Arrays.asList(new ChatMessage("user", "Hi"));
+        Map<String, Object> options = Collections.emptyMap();
+        String result = service.createChatCompletion("gpt-3", messages, options);
+        assertEquals("Hello world", result);
+    }
+}

--- a/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/ImageInputCompletionServiceImplTest.java
+++ b/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/ImageInputCompletionServiceImplTest.java
@@ -1,0 +1,31 @@
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+
+import io.github.ullas.k.prabhakar.openai.OpenAIClient;
+import io.github.ullas.k.prabhakar.openai.services.impl.ImageInputCompletionServiceImpl;
+import io.github.ullas.k.prabhakar.openai.vos.ImageContent;
+import io.github.ullas.k.prabhakar.openai.vos.ImageInputChatMessage;
+import io.github.ullas.k.prabhakar.openai.vos.ImageUrl;
+import junit.framework.TestCase;
+import org.mockito.Mockito;
+
+public class ImageInputCompletionServiceImplTest extends TestCase {
+    public void testCreateImageChatCompletion() throws Exception {
+        OpenAIClient client = Mockito.mock(OpenAIClient.class);
+        Mockito.when(client.getGson()).thenReturn(new Gson());
+        String json = "{\"choices\":[{\"message\":{\"content\":\"Image response\"}}]}";
+        Mockito.when(client.post(Mockito.eq("/chat/completions"), Mockito.any()))
+                .thenReturn(json);
+
+        ImageInputCompletionServiceImpl service = new ImageInputCompletionServiceImpl(client);
+        ImageContent content = new ImageContent("image_url", null, new ImageUrl("http://example.com/img.png"));
+        List<ImageInputChatMessage> messages = Arrays.asList(new ImageInputChatMessage("user", Arrays.asList(content)));
+        Map<String, Object> options = Collections.emptyMap();
+        String result = service.createImageChatCompletion("gpt-4", messages, options);
+        assertEquals("Image response", result);
+    }
+}

--- a/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/SpeechToTextServiceImplTest.java
+++ b/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/SpeechToTextServiceImplTest.java
@@ -1,0 +1,45 @@
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import com.google.gson.Gson;
+
+import io.github.ullas.k.prabhakar.openai.OpenAIClient;
+import io.github.ullas.k.prabhakar.openai.services.impl.SpeechToTextServiceImpl;
+import junit.framework.TestCase;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.mockito.Mockito;
+
+public class SpeechToTextServiceImplTest extends TestCase {
+    public void testTranscribeAudio() throws Exception {
+        OpenAIClient client = Mockito.mock(OpenAIClient.class);
+        OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+        Call call = Mockito.mock(Call.class);
+
+        Mockito.when(client.getBaseUrl()).thenReturn("http://localhost");
+        Mockito.when(client.getApiKey()).thenReturn("KEY");
+        Mockito.when(client.getHttpClient()).thenReturn(httpClient);
+        Mockito.when(client.getGson()).thenReturn(new Gson());
+        Mockito.when(httpClient.newCall(Mockito.any(Request.class))).thenReturn(call);
+
+        Response response = new Response.Builder()
+                .request(new Request.Builder().url("http://localhost").build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("{\"text\":\"done\"}", MediaType.parse("application/json")))
+                .build();
+        Mockito.when(call.execute()).thenReturn(response);
+
+        SpeechToTextServiceImpl service = new SpeechToTextServiceImpl(client);
+        Map<String, Object> options = Collections.emptyMap();
+        String result = service.transcribeAudio("whisper-1", new byte[]{1,2}, options);
+        assertEquals("done", result);
+    }
+}

--- a/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/TextToSpeechServiceImplTest.java
+++ b/src/test/java/io/github/ullas/k/prabhakar/openai/services/impl/TextToSpeechServiceImplTest.java
@@ -1,0 +1,25 @@
+import java.util.Collections;
+import java.util.Map;
+
+import io.github.ullas.k.prabhakar.openai.OpenAIClient;
+import io.github.ullas.k.prabhakar.openai.services.impl.TextToSpeechServiceImpl;
+import junit.framework.TestCase;
+import org.mockito.Mockito;
+
+public class TextToSpeechServiceImplTest extends TestCase {
+    public void testSynthesizeSpeech() throws Exception {
+        OpenAIClient client = Mockito.mock(OpenAIClient.class);
+        byte[] expected = new byte[] {1, 2, 3};
+        Mockito.when(client.postForBinary(Mockito.eq("/audio/speech"), Mockito.any()))
+                .thenReturn(expected);
+
+        TextToSpeechServiceImpl service = new TextToSpeechServiceImpl(client);
+        Map<String, Object> options = Collections.emptyMap();
+        byte[] result = service.synthesizeSpeech("tts-1", "Hello", options);
+        assertNotNull(result);
+        assertEquals(expected.length, result.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], result[i]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add mockito-core dependency
- test CompletionServiceImpl parsing logic
- test ImageInputCompletionServiceImpl
- test TextToSpeechServiceImpl for binary responses
- test SpeechToTextServiceImpl by mocking OkHttpClient

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555c6fdfb883309655df53ca8446bd