### PR TITLE
Add ImageContent tests

### DIFF
--- a/src/test/java/io/github/ullas/k/prabhakar/openai/vos/ImageContentTest.java
+++ b/src/test/java/io/github/ullas/k/prabhakar/openai/vos/ImageContentTest.java
@@ -1,0 +1,38 @@
+package io.github.ullas.k.prabhakar.openai.vos;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Collections;
+
+import junit.framework.TestCase;
+
+public class ImageContentTest extends TestCase {
+
+    public void testConstructorsProduceDataUri() throws Exception {
+        byte[] data = "hello".getBytes();
+        File temp = File.createTempFile("img", ".png");
+        temp.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(temp)) {
+            fos.write(data);
+        }
+
+        ImageContent fileContent = new ImageContent(temp);
+        assertNotNull(fileContent.getImageUrl());
+        assertTrue(fileContent.getImageUrl().getUrl().startsWith("data:"));
+
+        ImageContent byteContent = new ImageContent(data);
+        assertNotNull(byteContent.getImageUrl());
+        assertTrue(byteContent.getImageUrl().getUrl().startsWith("data:"));
+    }
+
+    public void testGetImageUrlNotNullAndToString() {
+        ImageContent empty = new ImageContent();
+        assertNotNull(empty.getImageUrl());
+
+        ImageContent content = new ImageContent();
+        ImageInputChatMessage msg = new ImageInputChatMessage("user", Collections.singletonList(content));
+        String str = msg.toString();
+        assertTrue(str.contains("role=user"));
+        assertTrue(str.contains("contents="));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ImageContentTest` with JUnit 3 test cases verifying constructors, `getImageUrl`, and `ImageInputChatMessage.toString()`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555c6b3f5c8330befa747b0a16527e